### PR TITLE
update wire instructions scene, add terms of conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@material-ui/core": "^4.4.3",
     "@material-ui/icons": "^4.4.3",
     "edge-libplugin": "https://github.com/EdgeApp/edge-libplugin.git#9744aaf61b80",
-    "edge-plugin-screens-and-components": "https://github.com/EdgeApp/edge-plugin-screens-and-components#84095fc",
+    "edge-plugin-screens-and-components": "https://github.com/EdgeApp/edge-plugin-screens-and-components#93b9b4390e5f",
     "eslint": "^5.12.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-import": "^2.7.0",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -84,7 +84,8 @@ export async function apiOrder(data: Object) {
     headers: {
       'Host': 'exchange.api.bity.com',
       'Accept': 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'Client-Id': '4949bf59-c23c-4d71-949e-f5fd56ff815b'
     },
     credentials: 'include',
     body: JSON.stringify(data)

--- a/src/connectors/IntroConnector.js
+++ b/src/connectors/IntroConnector.js
@@ -32,6 +32,11 @@ const mapStateToProps = (state: State) => {
       title: 'Support',
       body: 'For support please contact \nsupport@bity.com',
       list: []
+    },
+    {
+      title: 'Terms of Service',
+      body: 'Orders placed through the Bity Plugin are executed by bity. By creating orders you are agreeing to Bity\'s terms of service ',
+      list: []
     }
   ]
   return {

--- a/src/connectors/TransactionConfirmationConnector.js
+++ b/src/connectors/TransactionConfirmationConnector.js
@@ -27,7 +27,8 @@ const mapStateToProps = (state: State) => {
       onOfCurrencyCodeInFiat: null,
       buyOrSell: state.Transaction.type,
       poweredBy: POWERED_BY_LOGO,
-      processing: false
+      processing: false,
+      termsOfService: ''
     }
   }
   const isSell = state.Transaction.type === 'sell'
@@ -52,7 +53,8 @@ const mapStateToProps = (state: State) => {
     onOfCurrencyCodeInFiat: '€' + estimate.pricePerBTC,
     buyOrSell: state.Transaction.type,
     poweredBy: POWERED_BY_LOGO,
-    processing: state.Transaction.processing
+    processing: state.Transaction.processing,
+    termsOfService: 'By creating this order, you are agreeing to Bity\'s terms of service. The order will be executed by Bity'
   }
 }
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/connectors/WireInstructionsConnector.js
+++ b/src/connectors/WireInstructionsConnector.js
@@ -11,20 +11,25 @@ const mapStateToProps = (state: State) => {
   if(!wireInformation) {
     return {
       poweredBy: POWERED_BY_LOGO,
-      message
+      message,
+      title: 'Bank transfer instructions'
     }
   }
-  message.push('To complete your purchase. Send funds to Bity.  You must include the reference')
+  message.push('Please instruct your bank to do the following payment:')
+  message.push('IBAN: ' + wireInformation.iban)
+  message.push('Reference: ' + wireInformation.reference)
   message.push('Recipient: ' + wireInformation.recipient)
+  message.push('')
+  message.push('Additional Data:')
   message.push('Bank Address: ' + wireInformation.bank_address)
   message.push('Bank Code: ' + wireInformation.bank_code)
-  message.push('Account: ' + wireInformation.account)
-  message.push('IBAN: ' + wireInformation.iban)
+  message.push('Account: ' + wireInformation.account_number)
   message.push('SWIFT BIC: ' + wireInformation.swift_bic)
-  message.push('Reference: ' + wireInformation.reference)
+
   return {
     poweredBy: POWERED_BY_LOGO,
-    message
+    message,
+    title: 'Bank transfer instructions'
   }
 }
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/scenes/Navigation.js
+++ b/src/scenes/Navigation.js
@@ -19,7 +19,6 @@ import { TransactionAmountConnector } from '../connectors/TransactionAmountConne
 import { TransactionConfirmationConnector } from '../connectors/TransactionConfirmationConnector.js'
 import { TransactionSuccessConnector } from '../connectors/TransactionSuccessConnector.js'
 import { WireInstructionsConnector } from '../connectors/WireInstructionsConnector.js'
-import { IntroConnector } from '../connectors/IntroConnector.js'
 import { createMuiTheme } from '@material-ui/core/styles'
 import history from '../history/history';
 
@@ -40,7 +39,7 @@ const theme = createMuiTheme({
 
 export const routes = [{
   path: START_ROUTE,
-  main: IntroConnector,
+  main: StartSceneConnector,
   exact: true
 }, {
   path: BANK_CONNECT_ROUTE,

--- a/src/types/AppTypes.js
+++ b/src/types/AppTypes.js
@@ -84,7 +84,7 @@ export type OrderDetail = {
 }
 
 export type WireInformation = {
-  account: string,
+  account_number: string,
   bank_address: string,
   bank_code: string,
   iban: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4181,9 +4181,9 @@ ecc-jsbn@~0.1.1:
     pinkie-promise "^2.0.1"
     yargs "^8.0.2"
 
-"edge-plugin-screens-and-components@https://github.com/EdgeApp/edge-plugin-screens-and-components#84095fc":
+"edge-plugin-screens-and-components@https://github.com/EdgeApp/edge-plugin-screens-and-components#93b9b4390e5f":
   version "0.0.1"
-  resolved "https://github.com/EdgeApp/edge-plugin-screens-and-components#84095fc5e5460cb12d1be3d4ff07b02937aef75e"
+  resolved "https://github.com/EdgeApp/edge-plugin-screens-and-components#93b9b4390e5ff4d659e96503c6364f8a6e2bf5b9"
   dependencies:
     js-sha256 "^0.9.0"
 


### PR DESCRIPTION
This adds terms and conditions to the TransactionConfirmation Scene, the Intro Scene. Also the styles on the Wire Transfer scene are tightened up. In addition the initial route was reset to what it needed to be to keep from locking the user into just the intro component. 

Transfer scene content changed to reflect instructions from Bity